### PR TITLE
Fixed incorrect Vulkan blend parameter for alpha blending

### DIFF
--- a/third_party/kvf.h
+++ b/third_party/kvf.h
@@ -3189,7 +3189,7 @@ void kvfGPipelineBuilderEnableAlphaBlending(KvfGraphicsPipelineBuilder* builder)
 	builder->color_blend_attachment_state.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
 	builder->color_blend_attachment_state.colorBlendOp = VK_BLEND_OP_ADD;
 	builder->color_blend_attachment_state.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
-	builder->color_blend_attachment_state.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+	builder->color_blend_attachment_state.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
 	builder->color_blend_attachment_state.alphaBlendOp = VK_BLEND_OP_ADD;
 }
 


### PR DESCRIPTION
The previous implementation had an issues where color blending operations on semi-transparent backgrounds led to incorrect results (for example, blending a translucent color on a transparent background would lead to an opaque color), this should to fix the problem