### PR TITLE
Fix freeze when resizing a window

### DIFF
--- a/runtime/Includes/Core/Enums.h
+++ b/runtime/Includes/Core/Enums.h
@@ -19,9 +19,10 @@ namespace mlx
 
 	enum class Event
 	{
-		ResizeEventCode = 56,
-		FrameBeginEventCode = 57,
-		FatalErrorEventCode = 168,
+		ResizeEventCode = 1,
+		SwapchainResizeEventCode,
+		FrameBeginEventCode,
+		FatalErrorEventCode,
 
 		EndEnum
 	};

--- a/runtime/Sources/Platform/Inputs.cpp
+++ b/runtime/Sources/Platform/Inputs.cpp
@@ -8,9 +8,9 @@ namespace mlx
 {
 	namespace Internal
 	{
-		struct ResizeEventBroadcast : public EventBase
+		struct SwapchainResizeEventBroadcast : public EventBase
 		{
-			Event What() const override { return Event::ResizeEventCode; }
+			Event What() const override { return Event::SwapchainResizeEventCode; }
 		};
 	}
 
@@ -23,7 +23,7 @@ namespace mlx
 			if(!m_events_hooks.contains(window_id) || m_events_hooks[window_id][event].empty())
 				return;
 			if(event == MLX_WINDOW_EVENT && code == 8)
-				EventBus::SendBroadcast(Internal::ResizeEventBroadcast{});
+				EventBus::SendBroadcast(Internal::SwapchainResizeEventBroadcast{});
 			for(const auto& hook : m_events_hooks[window_id][event])
 			{
 				if(hook.fn)

--- a/runtime/Sources/Renderer/Swapchain.cpp
+++ b/runtime/Sources/Renderer/Swapchain.cpp
@@ -15,7 +15,7 @@ namespace mlx
 			Event What() const override { return Event::ResizeEventCode; }
 		};
 	}
-	
+
 	std::string VulkanFormatName(VkFormat format)
 	{
 		#define STRINGIFY(x) case x: return #x
@@ -161,7 +161,7 @@ namespace mlx
 
 		std::function<void(const EventBase&)> functor = [this](const EventBase& event)
 		{
-			if(event.What() == Event::ResizeEventCode && !m_resize)
+			if(event.What() == Event::SwapchainResizeEventCode && !m_resize)
 				m_resize = true;
 		};
 		EventBus::RegisterListener({ functor, "mlx_swapchain_" + std::to_string(reinterpret_cast<std::uintptr_t>(this)) });


### PR DESCRIPTION
Fixed an annoying bug where the application would freeze when resizing the window
This pull request made it so the SDL window's resizing event now broadcasts a new event specifically asking the swapchain to recreate itself, which will in turn broadcast the original event when done. It also removed the Event enum specific values, as they were irrelevant.