### PR TITLE
changed mlx_put_transformed_image_to_window to use float position

### DIFF
--- a/includes/mlx_extended.h
+++ b/includes/mlx_extended.h
@@ -153,7 +153,7 @@ MLX_API void mlx_set_image_region(mlx_context mlx, mlx_image image, int x, int y
  * @param scale_y    Scale y of the image
  * @param angle      Rotation angle of the image (clockwise)
  */
-MLX_API void mlx_put_transformed_image_to_window(mlx_context mlx, mlx_window win, mlx_image image, int x, int y, float scale_x, float scale_y, float angle);
+MLX_API void mlx_put_transformed_image_to_window(mlx_context mlx, mlx_window win, mlx_image image, float x, float y, float scale_x, float scale_y, float angle);
 
 /**
  * @brief            Get direct pointers to hidden functions

--- a/runtime/Includes/Core/Graphics.h
+++ b/runtime/Includes/Core/Graphics.h
@@ -28,7 +28,7 @@ namespace mlx
 			void PixelPutArray(int x, int y, mlx_color* color, std::size_t pixels_size) noexcept;
 			void PixelPutRegion(int x, int y, int w, int h, mlx_color* color) noexcept;
 			void StringPut(int x, int y, mlx_color color, std::string str);
-			void TexturePut(NonOwningPtr<class Texture> texture, int x, int y, float scale_x, float scale_y, float angle);
+			void TexturePut(NonOwningPtr<class Texture> texture, float x, float y, float scale_x, float scale_y, float angle);
 
 			inline void TryEraseSpritesInScene(NonOwningPtr<Texture> texture) noexcept;
 

--- a/runtime/Sources/Core/Bridge.cpp
+++ b/runtime/Sources/Core/Bridge.cpp
@@ -458,7 +458,7 @@ extern "C"
 		texture->SetRegion(x, y, w, h, pixels);
 	}
 
-	void mlx_put_transformed_image_to_window(mlx_context mlx, mlx_window win, mlx_image image, int x, int y, float scale_x, float scale_y, float angle)
+	void mlx_put_transformed_image_to_window(mlx_context mlx, mlx_window win, mlx_image image, float x, float y, float scale_x, float scale_y, float angle)
 	{
 		MLX_CHECK_APPLICATION_POINTER(mlx);
 		mlx::NonOwningPtr<mlx::GraphicsSupport> gs = mlx->app->GetGraphicsSupport(win);

--- a/runtime/Sources/Core/Graphics.cpp
+++ b/runtime/Sources/Core/Graphics.cpp
@@ -136,7 +136,7 @@ namespace mlx
 			p_scene->BringToDrawLayer(text.Get(), m_draw_layer);
 	}
 
-	void GraphicsSupport::TexturePut(NonOwningPtr<Texture> texture, int x, int y, float scale_x, float scale_y, float angle)
+	void GraphicsSupport::TexturePut(NonOwningPtr<Texture> texture, float x, float y, float scale_x, float scale_y, float angle)
 	{
 		MLX_PROFILE_FUNCTION();
 		NonOwningPtr<Sprite> sprite = p_scene->GetSpriteFromTexturePositionScaleRotation(texture, Vec2f{ static_cast<float>(x), static_cast<float>(y) }, scale_x, scale_y, angle);
@@ -146,14 +146,14 @@ namespace mlx
 			{
 				m_draw_layer++;
 				m_pixelput_called = false;
-			}	
+			}
 			Sprite& new_sprite = p_scene->CreateSprite(texture);
 			new_sprite.SetCenter(Vec2f{ texture->GetWidth() * 0.5f, texture->GetHeight() * 0.5f });
 			new_sprite.SetPosition(Vec2f{ static_cast<float>(x), static_cast<float>(y) });
 			new_sprite.SetScale(Vec2f{ scale_x, scale_y });
 			new_sprite.SetRotation(angle);
 		}
-		else if(!p_scene->IsTextureAtGivenDrawLayer(texture, m_draw_layer))	
+		else if(!p_scene->IsTextureAtGivenDrawLayer(texture, m_draw_layer))
 			p_scene->BringToDrawLayer(sprite.Get(), m_draw_layer);
 	}
 


### PR DESCRIPTION
Using integer positions (x and y), the displayed image could suffer from rounding errors with rotation. Leading to jittering on most dynamically resized images trying to fit the window while rotating (common optimization done in projects like Cub3D). This PR aims to fix this issue by using float parameters for positioning in the function